### PR TITLE
Reasonable naming of packages, proper use of underscore character

### DIFF
--- a/src/main/java/org/jraf/androidcontentprovidergenerator/Main.java
+++ b/src/main/java/org/jraf/androidcontentprovidergenerator/Main.java
@@ -232,7 +232,7 @@ public class Main {
 
         // Entities
         for (Entity entity : Model.get().getEntities()) {
-            File outputDir = new File(providerDir, entity.getNameLowerCase());
+            File outputDir = new File(providerDir, entity.getPackageName());
             outputDir.mkdirs();
             File outputFile = new File(outputDir, entity.getNameCamelCase() + "Columns.java");
             Writer out = new OutputStreamWriter(new FileOutputStream(outputFile));
@@ -278,7 +278,7 @@ public class Main {
 
         // Entities
         for (Entity entity : Model.get().getEntities()) {
-            File entityDir = new File(providerDir, entity.getNameLowerCase());
+            File entityDir = new File(providerDir, entity.getPackageName());
             entityDir.mkdirs();
 
             // Cursor wrapper

--- a/src/main/java/org/jraf/androidcontentprovidergenerator/model/Entity.java
+++ b/src/main/java/org/jraf/androidcontentprovidergenerator/model/Entity.java
@@ -27,6 +27,7 @@ package org.jraf.androidcontentprovidergenerator.model;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.lang.WordUtils;
 
@@ -59,12 +60,16 @@ public class Entity {
         return WordUtils.capitalizeFully(mName, new char[] { '_' }).replaceAll("_", "");
     }
 
+    public String getPackageName() {
+        return getNameLowerCase().replace("_", "");
+    }
+
     public String getNameLowerCase() {
-        return mName;
+        return mName.toLowerCase(Locale.US);
     }
 
     public String getNameUpperCase() {
-        return mName.toUpperCase();
+        return mName.toUpperCase(Locale.US);
     }
 
     @Override


### PR DESCRIPTION
Packages should not contain underscore characters and at the same time most java developers want to have CamelCase naming of their entities
