### PR TITLE
SQLiteOpenHelperCallbacks.onOpen not always called

### DIFF
--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/sqliteopenhelper.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/sqliteopenhelper.ftl
@@ -137,16 +137,18 @@ public class ${config.sqliteOpenHelperClassName} extends SQLiteOpenHelper {
         mOpenHelperCallbacks.onPostCreate(mContext, db);
     }
 
-    <#if config.enableForeignKeys >
     @Override
     public void onOpen(SQLiteDatabase db) {
         super.onOpen(db);
+        <#if config.enableForeignKeys >
         if (!db.isReadOnly()) {
             setForeignKeyConstraintsEnabled(db);
         }
+        </#if>
         mOpenHelperCallbacks.onOpen(mContext, db);
     }
 
+    <#if config.enableForeignKeys >
     private void setForeignKeyConstraintsEnabled(SQLiteDatabase db) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             setForeignKeyConstraintsEnabledPreJellyBean(db);
@@ -165,7 +167,6 @@ public class ${config.sqliteOpenHelperClassName} extends SQLiteOpenHelper {
     }
 
     </#if>
-
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         mOpenHelperCallbacks.onUpgrade(mContext, db, oldVersion, newVersion);


### PR DESCRIPTION
Correctly call mOpenHelperCallbacks.onOpen when foreign keys are disabled.
