### PR TITLE
fix problems with ambiguous column name _ID exceptions caused by _ID not...

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ https://github.com/BoD/android-contentprovider-generator/releases/latest
 
 ### Run the tool
 
-`java -jar android-contentprovider-generator-1.8.0-bundle.jar -i <input folder> -o <output folder>`
+`java -jar android-contentprovider-generator-1.8.1-bundle.jar -i <input folder> -o <output folder>`
 - Input folder: where to find `_config.json` and your entity json files
 - Output folder: where the resulting files will be generated
 
@@ -207,7 +207,7 @@ You need maven to build this tool.
 
 `mvn package`
 
-This will produce `android-contentprovider-generator-1.8.0-bundle.jar` in the `target` folder.
+This will produce `android-contentprovider-generator-1.8.1-bundle.jar` in the `target` folder.
 
 
 Similar tools

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.jraf</groupId>
     <artifactId>android_contentprovider_generator</artifactId>
-    <version>1.8.0</version> <!-- Do not forget to update README.md when updating this value -->
+    <version>1.8.1</version> <!-- Do not forget to update README.md when updating this value -->
     <packaging>jar</packaging>
 
     <name>GenerateAndroidProvider</name>

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/contentprovider.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/contentprovider.ftl
@@ -169,6 +169,7 @@ public class ${config.providerClassName} extends ContentProvider {
             Log.d(TAG, "query uri=" + uri + " selection=" + selection + " selectionArgs=" + Arrays.toString(selectionArgs) + " sortOrder=" + sortOrder
                     + " groupBy=" + groupBy);
         QueryParams queryParams = getQueryParams(uri, selection, projection);
+		ensureIDIsFullyQualified(projection, queryParams.table);
         Cursor res = m${config.sqliteOpenHelperClassName}.getReadableDatabase().query(queryParams.tablesWithJoins, projection, queryParams.selection, selectionArgs, groupBy,
                 null, sortOrder == null ? queryParams.orderBy : sortOrder);
         res.setNotificationUri(getContext().getContentResolver(), uri);
@@ -203,6 +204,16 @@ public class ${config.providerClassName} extends ContentProvider {
             db.endTransaction();
         }
     }
+	
+	private void ensureIDIsFullyQualified(String[] projection, String tableName) {
+        if (projection != null) {
+            for (int i = 0; i < projection.length; ++i) {
+                if (projection[i] == BaseColumns._ID) {
+                    projection[i] = tableName + "." + BaseColumns._ID;
+				}
+			}
+		}
+	}
 
     private static class QueryParams {
         public String table;
@@ -237,9 +248,9 @@ public class ${config.providerClassName} extends ContentProvider {
         }
         if (id != null) {
             if (selection != null) {
-                res.selection = BaseColumns._ID + "=" + id + " and (" + selection + ")";
+                res.selection = res.table + "." + BaseColumns._ID + "=" + id + " and (" + selection + ")";
             } else {
-                res.selection = BaseColumns._ID + "=" + id;
+                res.selection = res.table + "." + BaseColumns._ID + "=" + id;
             }
         } else {
             res.selection = selection;

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/selection.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/selection.ftl
@@ -51,7 +51,7 @@ public class ${entity.nameCamelCase}Selection extends AbstractSelection<${entity
 
 
     public ${entity.nameCamelCase}Selection id(long... value) {
-        addEquals(${entity.nameCamelCase}Columns._ID, toObjectArray(value));
+        addEquals("${entity.nameLowerCase}._ID", toObjectArray(value));
         return this;
     }
 


### PR DESCRIPTION
... being fully qualified in queries with joins

Awesome tool - Thankyou!

This commit fixes cases where android-contentprovider-generator was generating SQL select statements that caused exceptions similar to:

```
 android.database.sqlite.SQLiteException: ambiguous column name: _id (code 1): , while compiling: SELECT _id, distance FROM segment LEFT OUTER JOIN session ON segment.sessionid=session._id WHERE sessionid=? ORDER BY segment._id
```

With a schema like:

**segment.json:**

```
{
    "fields": [
        {
            "name": "distance",
            "type": "Integer",
            "nullable": "true",
        },
        {
            "name": "sessionId",
            "type": "Long",
            "nullable": false,
            "foreignKey": {
                "table": "Session",
                "onDelete": "CASCADE",
            }
        }
    ]
}
```

**session.json:**

```
{
    "fields": [
        {
            "name": "title",
            "type": "String",
            "nullable": "false",
        },
        {
            "name": "sessionStatus",
            "type": "enum",
            "enumName": "SessionStatus",
            "enumValues": [
                "PENDING",
                "ACTIVE",
                "COMPLETE"
            ],
            "nullable": "false",
        },
    ]
}
```

There were three cases causing such an exception:

**1.** Any query with "_ID" (specified as Segment._ID, for example) in the projection.  Note that most (all?) CursorAdapters _require_ "_ID" in the projection.  This case also has a bug in that a join was always applied since "_ID" is in both tables, even if the projection was only intended to access one table.

**2.** A query of the form getContentResolver("foo.bar/segment/#3")

**3.** A query like something.id(456).query(...) on an entity (table) with a foreign key.
