### PR TITLE
Allow foreign key filed names to be the same

### DIFF
--- a/src/main/java/org/jraf/androidcontentprovidergenerator/model/Entity.java
+++ b/src/main/java/org/jraf/androidcontentprovidergenerator/model/Entity.java
@@ -69,16 +69,19 @@ public class Entity {
         return Collections.unmodifiableList(mFields);
     }
 
-    public List<Field> getFieldsIncludingJoins() {
+    public List<Field> getFieldsIncludingJoins(boolean isForeign) {
         List<Field> res = new ArrayList<>();
-        res.addAll(mFields);
+        for (Field field : mFields) {
+			field.setForeign(isForeign);
+			res.add(field);
+		}
 
         for (Field field : getFields()) {
             ForeignKey foreignKey = field.getForeignKey();
             if (foreignKey == null) continue;
 
             // Recurse
-            res.addAll(foreignKey.getEntity().getFieldsIncludingJoins());
+            res.addAll(foreignKey.getEntity().getFieldsIncludingJoins(true));
         }
 
         return res;

--- a/src/main/java/org/jraf/androidcontentprovidergenerator/model/Field.java
+++ b/src/main/java/org/jraf/androidcontentprovidergenerator/model/Field.java
@@ -146,6 +146,7 @@ public class Field {
     private final String mEnumName;
     private final List<EnumValue> mEnumValues = new ArrayList<>();
     private final ForeignKey mForeignKey;
+	private boolean foreign;
 
     public Field(Entity entity, String name, String type, boolean isId, boolean isIndex, boolean isNullable, String defaultValue, String enumName,
             List<EnumValue> enumValues, ForeignKey foreignKey) {
@@ -241,4 +242,19 @@ public class Field {
         return "Field [mName=" + mName + ", mType=" + mType + ", mIsId=" + mIsId + ", mIsIndex=" + mIsIndex + ", mIsNullable=" + mIsNullable
                 + ", mDefaultValue=" + mDefaultValue + ", mEnumName=" + mEnumName + ", mEnumValues=" + mEnumValues + ", mForeignKey=" + mForeignKey + "]";
     }
+
+	/**
+	 * @param isForeign
+	 */
+	public void setForeign(boolean isForeign) {
+		this.foreign = isForeign;
+		
+	}
+	
+	/**
+	 * @return the foreign
+	 */
+	public boolean getIsForeign() {
+		return foreign;
+	}
 }

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/cursor.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/cursor.ftl
@@ -19,7 +19,7 @@ public class ${entity.nameCamelCase}Cursor extends AbstractCursor {
     public ${entity.nameCamelCase}Cursor(Cursor cursor) {
         super(cursor);
     }
-    <#list entity.fieldsIncludingJoins as field>
+    <#list entity.getFieldsIncludingJoins(false) as field>
         <#if !field.isId>
 
     /**
@@ -32,7 +32,7 @@ public class ${entity.nameCamelCase}Cursor extends AbstractCursor {
             </#if>
         </#if>
      */
-    public ${field.javaTypeSimpleName} get${field.nameCamelCase}() {
+    public ${field.javaTypeSimpleName} get<#if field.isForeign>${field.entity.nameCamelCase}</#if>${field.nameCamelCase}() {
             <#switch field.type.name()>
             <#case "STRING">
         Integer index = getCachedColumnIndexOrThrow(${field.entity.nameCamelCase}Columns.${field.nameUpperCase});


### PR DESCRIPTION
The cursor methods are now:

`getTableNameFieldName` for foreign keys
