### PR TITLE
Using column name specified in Columns in foreign key constraint

### DIFF
--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/sqliteopenhelper.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/sqliteopenhelper.ftl
@@ -53,7 +53,7 @@ public class ${config.sqliteOpenHelperClassName} extends SQLiteOpenHelper {
             <#if config.enableForeignKeys >
                 <#list entity.fields as field>
                     <#if field.foreignKey??>
-            + ", CONSTRAINT fk_${field.nameLowerCase} FOREIGN KEY (${field.nameLowerCase}) REFERENCES ${field.foreignKey.entity.nameLowerCase} (${field.foreignKey.field.nameLowerCase}) ON DELETE ${field.foreignKey.onDeleteAction}"
+            + ", CONSTRAINT fk_${field.nameLowerCase} FOREIGN KEY (" + ${entity.nameCamelCase}Columns.${field.nameUpperCase} + ") REFERENCES ${field.foreignKey.entity.nameLowerCase} (${field.foreignKey.field.nameLowerCase}) ON DELETE ${field.foreignKey.onDeleteAction}"
                     </#if>
                 </#list>
             </#if>


### PR DESCRIPTION
I had an issue where column names were prefixed to remove ambiguity, but the prefixed names weren't being used in the foreign key constraints (leading to "unknown column" errors when creating the tables). This should fix it.
