### PR TITLE
optionally keep the case of database field as in defined the table.json

### DIFF
--- a/src/main/java/org/jraf/androidcontentprovidergenerator/Constants.java
+++ b/src/main/java/org/jraf/androidcontentprovidergenerator/Constants.java
@@ -25,6 +25,6 @@
 package org.jraf.androidcontentprovidergenerator;
 
 public class Constants {
-    public static final String SYNTAX_VERSION = "2";
+    public static final String SYNTAX_VERSION = "2.1";
     public static final String TAG = "";
 }

--- a/src/main/java/org/jraf/androidcontentprovidergenerator/Main.java
+++ b/src/main/java/org/jraf/androidcontentprovidergenerator/Main.java
@@ -74,6 +74,7 @@ public class Main {
         public static final String DATABASE_FILE_NAME = "databaseFileName";
         public static final String DATABASE_VERSION = "databaseVersion";
         public static final String ENABLE_FOREIGN_KEY = "enableForeignKeys";
+        public static final String FIELD_CASE_NAME = "keepFieldCase";
     }
 
     private Configuration mFreemarkerConfig;
@@ -223,6 +224,7 @@ public class Main {
         ensureString(Json.PROVIDER_CLASS_NAME);
         ensureString(Json.SQLITE_OPEN_HELPER_CLASS_NAME);
         ensureString(Json.SQLITE_OPEN_HELPER_CALLBACKS_CLASS_NAME);
+        ensureBoolean(Json.FIELD_CASE_NAME);
         ensureString(Json.AUTHORITY);
         ensureString(Json.DATABASE_FILE_NAME);
         ensureInt(Json.DATABASE_VERSION);

--- a/src/main/java/org/jraf/androidcontentprovidergenerator/model/Field.java
+++ b/src/main/java/org/jraf/androidcontentprovidergenerator/model/Field.java
@@ -206,6 +206,15 @@ public class Field {
         return mEnumValues;
     }
 
+    public String getPrefixedCaseName() {
+        return mEntity.getNameLowerCase() + "__" + mName;
+    }
+
+    public String getCaseFieldNameOrPrefixed() {
+        if (mIsAmbiguous) return getPrefixedCaseName();
+        return mName;
+    }
+
     public String getPrefixedName() {
         return mEntity.getNameLowerCase() + "__" + getNameLowerCase();
     }

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/columns.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/columns.ftl
@@ -31,7 +31,7 @@ public class ${entity.nameCamelCase}Columns implements BaseColumns {
     <#if field.isId>
     public static final String ${field.nameUpperCase} = new String(BaseColumns._ID);
     <#else>
-    public static final String ${field.nameUpperCase} = "${field.nameLowerCaseOrPrefixed}";
+    public static final String ${field.nameUpperCase} = <#if config.keepFieldCase>"${field.caseFieldNameOrPrefixed}"<#else>"${field.nameLowerCaseOrPrefixed}"</#if>;
     </#if>
 
     </#list>


### PR DESCRIPTION
So the Content-Provider generator can be used to generate code for pre-existing databases.