### PR TITLE
clean the _id check to be comptible with a generator that has no _id field

### DIFF
--- a/src/main/java/org/jraf/androidcontentprovidergenerator/model/Entity.java
+++ b/src/main/java/org/jraf/androidcontentprovidergenerator/model/Entity.java
@@ -93,7 +93,7 @@ public class Entity {
     private List<Field> getFieldsIncludingJoins(boolean isForeign, String path) {
         List<Field> res = new ArrayList<>();
         for (Field field : mFields) {
-            if (field.getIsId()) continue;
+            if (field.getIsId() && isForeign) continue;
 
             if (isForeign) {
                 res.add(field.asForeignField(path));

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/basemodel.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/basemodel.ftl
@@ -4,5 +4,4 @@ ${header}
 package ${config.providerJavaPackage}.base;
 
 public interface BaseModel {
-    long getId();
 }

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/columns.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/columns.ftl
@@ -33,6 +33,7 @@ public class ${entity.nameCamelCase}Columns implements BaseColumns {
     public static final String _ID = BaseColumns._ID;
             <#else>
     public static final String _ID = "${field.nameOrPrefixed}";
+
     public static final String ${field.nameUpperCase} = "${field.nameOrPrefixed}";
             </#if>
         <#else>
@@ -59,7 +60,7 @@ public class ${entity.nameCamelCase}Columns implements BaseColumns {
         if (projection == null) return true;
         for (String c : projection) {
         <#list entity.fields as field>
-            <#if !field.isId>
+            <#if field.nameLowerCase != "_id">
             if (c == ${field.nameUpperCase} || c.contains("." + ${field.nameUpperCase})) return true;
             </#if>
         </#list>

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/contentvalues.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/contentvalues.ftl
@@ -33,7 +33,7 @@ public class ${entity.nameCamelCase}ContentValues extends AbstractContentValues 
         return contentResolver.update(uri(), values(), where == null ? null : where.sel(), where == null ? null : where.args());
     }
     <#list entity.fields as field>
-        <#if !field.isId>
+        <#if field.nameLowerCase != "_id">
 
     <#if field.documentation??>
     /**
@@ -69,14 +69,13 @@ public class ${entity.nameCamelCase}ContentValues extends AbstractContentValues 
         return this;
     }
             </#if>
-
             <#switch field.type.name()>
             <#case "DATE">
+
     public ${entity.nameCamelCase}ContentValues put${field.nameCamelCase}(<#if field.isNullable><#if config.useAnnotations>@Nullable </#if>Long<#else>long</#if> value) {
         mContentValues.put(${entity.nameCamelCase}Columns.${field.nameUpperCase}, value);
         return this;
     }
-
             <#break>
             </#switch>
         </#if>

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/cursor.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/cursor.ftl
@@ -23,13 +23,13 @@ public class ${entity.nameCamelCase}Cursor extends AbstractCursor implements ${e
     public ${entity.nameCamelCase}Cursor(Cursor cursor) {
         super(cursor);
     }
-
-    @Override
-    public long getId() {
-        return getLongOrNull(${entity.nameCamelCase}Columns._ID);
-    }
     <#list entity.getFieldsIncludingJoins() as field>
-        <#if !field.isId>
+    <#if field.isId && field.nameLowerCase != '_id'>
+
+    public long getId() {
+        return getLongOrNull(${field.entity.nameCamelCase}Columns._ID);
+    }
+    </#if>
 
     /**
     <#if field.documentation??>
@@ -113,6 +113,5 @@ public class ${entity.nameCamelCase}Cursor extends AbstractCursor implements ${e
             <#break>
             </#switch>
     }
-        </#if>
     </#list>
 }

--- a/src/main/resources/org/jraf/androidcontentprovidergenerator/selection.ftl
+++ b/src/main/resources/org/jraf/androidcontentprovidergenerator/selection.ftl
@@ -59,7 +59,7 @@ public class ${entity.nameCamelCase}Selection extends AbstractSelection<${entity
     }
 
     <#list entity.getFieldsIncludingJoins() as field>
-    <#if !field.isId>
+    <#if field.nameLowerCase != "_id">
     <#switch field.type.name()>
     <#case "BOOLEAN">
 


### PR DESCRIPTION
(to use in a Map)

So the Model doesn't have a `getId()` by default, but each Content-Provider ones have an implementation.